### PR TITLE
CR-1185333: Update pts data type to 64-bit signed integer

### DIFF
--- a/src/xma/include/app/xmabuffers.h
+++ b/src/xma/include/app/xmabuffers.h
@@ -164,7 +164,7 @@ typedef struct XmaDataBuffer
     XmaBufferRef    data; /**< description of data buffer*/
     int32_t         alloc_size; /**< allocated size of data buffer */
     int32_t         is_eof; /**< flag to indicate that this buffer is EOF */
-    int32_t         pts; /**< presentation time stamp looping back to application */
+    int64_t         pts; /**< presentation time stamp looping back to application */
     int32_t         poc; /**< Picture order count for current output frame */
 } XmaDataBuffer;
 

--- a/src/xma/xma_legacy/include/app/xmabuffers.h
+++ b/src/xma/xma_legacy/include/app/xmabuffers.h
@@ -111,7 +111,7 @@ typedef struct XmaDataBuffer
     XmaBufferRef    data; /**< description of data buffer*/
     int32_t         alloc_size; /**< allocated size of data buffer */
     int32_t         is_eof; /**< flag to indicate that this buffer is EOF */
-    int32_t         pts; /**< presentation time stamp looping back to application */
+    int64_t         pts; /**< presentation time stamp looping back to application */
     int32_t         poc; /**< Picture order count for current output frame */
 } XmaDataBuffer;
 


### PR DESCRIPTION
CR-1185333: Update pts data type to 64-bit signed integer

This commit in XRT repository and another commit in app-ffmpeg-xma repository
fixes malformed time stamps due to restriction in pts size when copyts is used.

**CR-1185333 reported the following bugs in GA3:**
1. Video stream not generated due to malformed time stamps when copyts is used.
2. 1 second delay in A/V synchronization when copyts is not used.

Changing pts data type from 32 bit signed integer to 64 bit signed integer in XRT and app-ffmpeg-xma,
along with using xma plugins built with fixed XRT, fixes the malformed time stamps issue.
The 1 second A/V synchronization difference has been reduced with commit "Fix high memory consumption in decoder (#117)" in app-ffmpeg-xma repository.

**Before fix:**
with copyts:
Video stream not generated

Without copyts:
A/V sync:
frame,audio,1,1,200895,2.232167,200895,2.232167,200895,2.232167,1920,0.021333,N/A,368,fltp,1024,2,stereo
frame,video,0,1,126840,1.409333,126840,1.409333,126840,1.409333,3600,0.040000,13912,64179,1920,1080,yuv420p,1:1,I,0,0,0,0,0,tv,unknown,unknown,unknown,left

frame,audio,1,1,216255,2.402833,216255,2.402833,216255,2.402833,1920,0.021333,N/A,351,fltp,1024,2,stereo
frame,video,0,0,130440,1.449333,130440,1.449333,130440,1.449333,3600,0.040000,94564,1279,1920,1080,yuv420p,1:1,B,2,0,0,0,0,tv,unknown,unknown,unknown,left

**After fix:**
with copyts:
A/V sync:
frame,audio,1,1,6898075123,76645.279144,6898075123,76645.279144,6898075123,76645.279144,1920,0.021333,N/A,336,fltp,1024,2,stereo
frame,video,0,1,6898046400,76644.960000,6898046400,76644.960000,6898046400,76644.960000,3600,0.040000,3760,64179,1920,1080,yuv420p,1:1,I,0,0,0,0,0,tv,unknown,unknown,unknown,left

frame,audio,1,1,6898090483,76645.449811,6898090483,76645.449811,6898090483,76645.449811,1920,0.021333,N/A,355,fltp,1024,2,stereo
frame,video,0,0,6898053600,76645.040000,6898053600,76645.040000,6898053600,76645.040000,3600,0.040000,85916,1218,1920,1080,yuv420p,1:1,B,3,0,0,0,0,tv,unknown,unknown,unknown,left

Without copyts:
A/V sync:
frame,audio,1,1,154815,1.720167,154815,1.720167,154815,1.720167,1920,0.021333,N/A,336,fltp,1024,2,stereo
frame,video,0,1,126840,1.409333,126840,1.409333,126840,1.409333,3600,0.040000,3760,64179,1920,1080,yuv420p,1:1,I,0,0,0,0,0,tv,unknown,unknown,unknown,left

frame,audio,1,1,170175,1.890833,170175,1.890833,170175,1.890833,1920,0.021333,N/A,355,fltp,1024,2,stereo
frame,video,0,0,134040,1.489333,134040,1.489333,134040,1.489333,3600,0.040000,85916,1218,1920,1080,yuv420p,1:1,B,3,0,0,0,0,tv,unknown,unknown,unknown,left

Full ffprobe outputs:
[ff514_copyts_ffprobe.log](https://github.com/sureshreddyavula/XRT/files/15321353/ff514_copyts_ffprobe.log)
[ff514_noCopyts_ffprobe.log](https://github.com/sureshreddyavula/XRT/files/15321356/ff514_noCopyts_ffprobe.log)
[ff514_Fix_copyts_ffprobe.log](https://github.com/sureshreddyavula/XRT/files/15321354/ff514_Fix_copyts_ffprobe.log)
[ff514_Fix_noCopyts_ffprobe.log](https://github.com/sureshreddyavula/XRT/files/15321355/ff514_Fix_noCopyts_ffprobe.log)

@sureshreddyavula
Please take a look at this
